### PR TITLE
Bug/special characters title

### DIFF
--- a/Src/AutoSpectre.SourceGeneration.Tests/TextPromptGeneratorTests.cs
+++ b/Src/AutoSpectre.SourceGeneration.Tests/TextPromptGeneratorTests.cs
@@ -30,6 +30,29 @@ public class TextPromptGeneratorTests : AutoSpectreGeneratorTestsBase
     }
 
     [Fact]
+    public void TextPromptWithSpecialCharacter()
+    {
+        GetOutput("""
+                  using AutoSpectre;
+                  using System.Collections.Generic;
+
+                  namespace Test;
+
+                  [AutoSpectreForm]
+                  public class TestForm
+                  {
+                      [TextPrompt(Title="\"test")]
+                      public string Secret {get;set;}
+                      
+                     
+                  }
+
+                  
+
+                  """).Output.Should().Contain("\"test");
+    }
+
+    [Fact]
     public void TextPromptWithReferenceToOtherThatHasNoEmptyPublicConstructorButItHasInitializer()
     {
         GetOutput("""

--- a/Src/AutoSpectre.SourceGeneration/AutoSpectre.SourceGeneration.csproj
+++ b/Src/AutoSpectre.SourceGeneration/AutoSpectre.SourceGeneration.csproj
@@ -8,7 +8,7 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsRoslynComponent>true</IsRoslynComponent>
     <VersionPrefix>0.8.2</VersionPrefix>
-    <VersionSuffix>preview-01</VersionSuffix>
+    <VersionSuffix>preview-02</VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Src/AutoSpectre.SourceGeneration/AutoSpectre.SourceGeneration.csproj
+++ b/Src/AutoSpectre.SourceGeneration/AutoSpectre.SourceGeneration.csproj
@@ -7,7 +7,8 @@
     <Nullable>enable</Nullable>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsRoslynComponent>true</IsRoslynComponent>
-    <VersionPrefix>0.8.1</VersionPrefix>    
+    <VersionPrefix>0.8.2</VersionPrefix>
+    <VersionSuffix>preview-01</VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Src/AutoSpectre.SourceGeneration/AutoSpectre.SourceGeneration.csproj
+++ b/Src/AutoSpectre.SourceGeneration/AutoSpectre.SourceGeneration.csproj
@@ -7,8 +7,7 @@
     <Nullable>enable</Nullable>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IsRoslynComponent>true</IsRoslynComponent>
-    <VersionPrefix>0.8.2</VersionPrefix>
-    <VersionSuffix>preview-02</VersionSuffix>
+    <VersionPrefix>0.8.2</VersionPrefix>    
   </PropertyGroup>
 
   <PropertyGroup>
@@ -22,7 +21,7 @@
     <PackageProjectUrl>https://github.com/jeppevammenkristensen/auto-spectre</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jeppevammenkristensen/auto-spectre</RepositoryUrl>
     <PackageTags>C#;Source Generator</PackageTags>
-    <PackageReleaseNotes>Focus on issues preventing build. Added handling of UsedConstructor</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixes issue with how Title is rendered</PackageReleaseNotes>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/ConfirmPromptBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/ConfirmPromptBuildContext.cs
@@ -6,13 +6,11 @@ namespace AutoSpectre.SourceGeneration.BuildContexts;
 
 public class ConfirmPromptBuildContext : PromptBuildContext
 {
-    public string Title { get; }
     public bool IsNullable { get; }
 
     public ConfirmPromptBuildContext(string title, bool isNullable,
-        SinglePropertyEvaluationContext evaluationContext) : base(evaluationContext)
+        SinglePropertyEvaluationContext evaluationContext) : base(evaluationContext, title)
     {
-        Title = title;
         IsNullable = isNullable;
     }
 
@@ -24,7 +22,7 @@ public class ConfirmPromptBuildContext : PromptBuildContext
     public override string PromptPart(string? variableName = null)
     {
         var stringBuilder = new StringBuilder();
-        stringBuilder.AppendLine($"""AnsiConsole.Prompt(new ConfirmationPrompt("{Title}")""");
+        stringBuilder.AppendLine($"""AnsiConsole.Prompt(new ConfirmationPrompt({GenerateTitleString()})""");
         BuildDefaultStyle(stringBuilder);
         BuildChoicesStyle(stringBuilder);
         stringBuilder.AppendLine(")");

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/EnumPromptBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/EnumPromptBuildContext.cs
@@ -5,14 +5,13 @@ namespace AutoSpectre.SourceGeneration.BuildContexts;
 
 public class EnumPromptBuildContext : PromptBuildContext
 {
-    public string Title { get; }
+   
     public ITypeSymbol Type { get; }
     public bool IsNullable { get; }
 
     public EnumPromptBuildContext(string title, ITypeSymbol type, bool isNullable,
-        SinglePropertyEvaluationContext context) : base(context)
+        SinglePropertyEvaluationContext context) : base(context, title)
     {
-        Title = title;
         Type = type;
         IsNullable = isNullable;
     }
@@ -28,7 +27,7 @@ public class EnumPromptBuildContext : PromptBuildContext
         return $"""
         AnsiConsole.Prompt(
         new SelectionPrompt<{type}>()
-            .Title("{Title}")
+            .Title({GenerateTitleString()})
             .PageSize(10) 
             .AddChoices(Enum.GetValues<{type}>()))
         """;

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/MultiAddBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/MultiAddBuildContext.cs
@@ -20,7 +20,7 @@ public class MultiAddBuildContext : PromptBuildContext
     private readonly SinglePropertyEvaluationContext? _childEvaluationContext;
 
     public MultiAddBuildContext(ITypeSymbol type, ITypeSymbol underlyingType, LazyTypes lazyTypes,
-        PromptBuildContext buildContext, SinglePropertyEvaluationContext context) : base(context)
+        PromptBuildContext buildContext, SinglePropertyEvaluationContext context) : base(context, string.Empty)
     {
         _type = type;
         _underlyingType = underlyingType;

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/MultiSelectionBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/MultiSelectionBuildContext.cs
@@ -47,7 +47,7 @@ internal class MultiSelectionBuildContext : SelectionBaseBuildContext
         var prompt = $"""
 AnsiConsole.Prompt(
 new MultiSelectionPrompt<{type}>()
-.Title("{Title}"){GenerateConverter()}
+.Title({GenerateTitleString()}){GenerateConverter()}
 {GenerateRequired()}
 {GeneratePageSize()}
 {GenerateHighlightStyle()}

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/PromptBuilderContextWithPropertyContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/PromptBuilderContextWithPropertyContext.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace AutoSpectre.SourceGeneration.BuildContexts;
 
 internal abstract class PromptBuilderContextWithPropertyContext : PromptBuildContext
 {
-    protected PromptBuilderContextWithPropertyContext(SinglePropertyEvaluationContext context) : base(context)
+    protected PromptBuilderContextWithPropertyContext(SinglePropertyEvaluationContext context, string title) : base(context, title)
     {
     }
 
@@ -18,5 +19,9 @@ internal abstract class PromptBuilderContextWithPropertyContext : PromptBuildCon
         return string.Empty;
     }
 
-   
+
+    
+
+
+
 }

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/ReuseExistingAutoSpectreFactoryPromptBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/ReuseExistingAutoSpectreFactoryPromptBuildContext.cs
@@ -13,8 +13,7 @@ internal class ReuseExistingAutoSpectreFactoryPromptBuildContext : PromptBuilder
     public override bool DeclaresVariable => true;
 
     private ConfirmedNamedTypeSource NamedTypeSource => Context.ConfirmedNamedTypeSource ?? throw new InvalidOperationException("Source was unexpectedly null");
-
-    public string Title { get; }
+   
     public INamedTypeSymbol NamedTypeSymbol { get; }
     public bool IsNullable { get; }
 
@@ -30,13 +29,11 @@ internal class ReuseExistingAutoSpectreFactoryPromptBuildContext : PromptBuilder
 
 
     public ReuseExistingAutoSpectreFactoryPromptBuildContext(string title, INamedTypeSymbol namedTypeSymbol,
-        bool isNullable, SinglePropertyEvaluationContext context) : base(context)
+        bool isNullable, SinglePropertyEvaluationContext context) : base(context, title)
     {
         if (context.ConfirmedNamedTypeSource is null)
             throw new InvalidOperationException("Expected that context.ConfirmedNamedTypeSource is not null");
 
-
-        Title = title;
         NamedTypeSymbol = namedTypeSymbol;
         IsNullable = isNullable;
 
@@ -80,7 +77,7 @@ internal class ReuseExistingAutoSpectreFactoryPromptBuildContext : PromptBuilder
             var usedVariableName = variableName ?? "item";
 
             return $"""
-            AnsiConsole.MarkupLine("{Title}");
+            AnsiConsole.MarkupLine({GenerateTitleString()});
             { InitializeVariable(usedVariableName) }
              { GetValueFromFactory(usedVariableName)}
             """;
@@ -94,7 +91,7 @@ internal class ReuseExistingAutoSpectreFactoryPromptBuildContext : PromptBuilder
 
             while (!isValid)
             { 
-                AnsiConsole.MarkupLine("{{Title}}");
+                AnsiConsole.MarkupLine({{GenerateTitleString()}});
                 {{ InitializeVariable(usedVariable) }}
                 {{ GetValueFromFactory(usedVariable)}}
 

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/SelectionBaseBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/SelectionBaseBuildContext.cs
@@ -7,12 +7,10 @@ namespace AutoSpectre.SourceGeneration.BuildContexts;
 /// </summary>
 internal abstract class SelectionBaseBuildContext : PromptBuilderContextWithPropertyContext
 {
-    public string Title { get; }
 
-
-    protected SelectionBaseBuildContext(string title,SinglePropertyEvaluationContext context) : base(context)
+    protected SelectionBaseBuildContext(string title,SinglePropertyEvaluationContext context) : base(context, title)
     {
-        Title = title;
+        
     }
 
     protected string GenerateMoreChoicesText()

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/SelectionPromptBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/SelectionPromptBuildContext.cs
@@ -8,8 +8,7 @@ namespace AutoSpectre.SourceGeneration.BuildContexts;
 internal class SelectionPromptBuildContext : SelectionBaseBuildContext
 {
     public ITypeSymbol TypeSymbol { get; }
-    public bool Nullable { get; }
-    
+    public bool Nullable { get; }    
 
     public SelectionPromptBuildContext(string title, SinglePropertyEvaluationContext context) : base(title,context)
     {
@@ -22,7 +21,6 @@ internal class SelectionPromptBuildContext : SelectionBaseBuildContext
     public override string GenerateOutput(string destination)
     {
         return $"{destination} = {PromptPart()};";
-
     }
 
     public override string PromptPart(string? variableName = null)
@@ -32,7 +30,7 @@ internal class SelectionPromptBuildContext : SelectionBaseBuildContext
         return $"""
         AnsiConsole.Prompt(
         new SelectionPrompt<{type}>()
-            .Title("{Title}"){GenerateConverter()}
+            .Title({GenerateTitleString()} ){GenerateConverter()}
             {GeneratePageSize()}
             {GenerateWrapAround()}
             {GenerateMoreChoicesText()}

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/TaskStepBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/TaskStepBuildContext.cs
@@ -6,12 +6,12 @@ namespace AutoSpectre.SourceGeneration.BuildContexts;
 
 public class TaskStepBuildContext : PromptBuildContext
 {
-    public string? Title { get; }
-
+    private bool _generateTitle;
+    
     public TaskStepBuildContext(string? title, SingleMethodEvaluationContext methodEvaluationContext) : base(
-        SinglePropertyEvaluationContext.Empty)
+        SinglePropertyEvaluationContext.Empty, title ?? string.Empty)
     {
-        Title = title;
+        _generateTitle = title is { };
         EvaluationContext = methodEvaluationContext;
     }
 
@@ -20,9 +20,9 @@ public class TaskStepBuildContext : PromptBuildContext
     public override string GenerateOutput(string destination)
     {
         var builder = new StringBuilder();
-        if (Title is { })
+        if (_generateTitle)
         {
-            builder.AppendLine($"AnsiConsole.MarkupLine(\"{Title}\");");    
+            builder.AppendLine($"AnsiConsole.MarkupLine({GenerateTitleString()});");    
         }
         
         StartStatus(builder);
@@ -88,7 +88,7 @@ public class TaskStepBuildContext : PromptBuildContext
 
     private void EndStatus(StringBuilder builder)
     {
-        if (EvaluationContext.ConfirmedStatus is not {} status)
+        if (EvaluationContext.ConfirmedStatus is not {})
         {
             return;
         }

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/TextPromptBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/TextPromptBuildContext.cs
@@ -13,12 +13,12 @@ namespace AutoSpectre.SourceGeneration.BuildContexts;
 internal class TextPromptBuildContext : PromptBuilderContextWithPropertyContext
 {
     private readonly TranslatedMemberAttributeData _memberAttributeData;
-    public string Title => _memberAttributeData.Title;
+    
     public ITypeSymbol TypeSymbol { get; }
     public bool Nullable { get; }
 
     public TextPromptBuildContext(TranslatedMemberAttributeData memberAttributeData, ITypeSymbol typeSymbol, bool nullable,
-        SinglePropertyEvaluationContext context) : base(context)
+        SinglePropertyEvaluationContext context) : base(context,memberAttributeData.Title)
     {
         _memberAttributeData = memberAttributeData;
         TypeSymbol = typeSymbol;
@@ -35,7 +35,7 @@ internal class TextPromptBuildContext : PromptBuilderContextWithPropertyContext
         var syntax = TypeSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax().ToString() ?? TypeSymbol.ToDisplayString();
         StringBuilder builder = new();
         builder.AppendLine("AnsiConsole.Prompt(");
-        builder.AppendLine($"""new TextPrompt<{syntax}>({SymbolDisplay.FormatLiteral(Title,true)})""");
+        builder.AppendLine($"""new TextPrompt<{syntax}>({GenerateTitleString()})""");
         if (Nullable)
         {
             builder.AppendLine(".AllowEmpty()");

--- a/Src/AutoSpectre.SourceGeneration/BuildContexts/TextPromptBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/BuildContexts/TextPromptBuildContext.cs
@@ -5,6 +5,7 @@ using System.Net.Mime;
 using System.Text;
 using AutoSpectre.SourceGeneration.Evaluation;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Spectre.Console;
 
 namespace AutoSpectre.SourceGeneration.BuildContexts;
@@ -34,7 +35,7 @@ internal class TextPromptBuildContext : PromptBuilderContextWithPropertyContext
         var syntax = TypeSymbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax().ToString() ?? TypeSymbol.ToDisplayString();
         StringBuilder builder = new();
         builder.AppendLine("AnsiConsole.Prompt(");
-        builder.AppendLine($"""new TextPrompt<{syntax}>("{Title}")""");
+        builder.AppendLine($"""new TextPrompt<{syntax}>({SymbolDisplay.FormatLiteral(Title,true)})""");
         if (Nullable)
         {
             builder.AppendLine(".AllowEmpty()");

--- a/Src/AutoSpectre.SourceGeneration/PromptBuildContext.cs
+++ b/Src/AutoSpectre.SourceGeneration/PromptBuildContext.cs
@@ -1,15 +1,18 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Composition.Hosting.Core;
 using System.Linq;
 using AutoSpectre.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace AutoSpectre.SourceGeneration;
 
 public abstract class PromptBuildContext
 {
-    public PromptBuildContext(SinglePropertyEvaluationContext context)
+    public PromptBuildContext(SinglePropertyEvaluationContext context, string title)
     {
         Context = context;
+        Title = title;
     }
 
     public virtual bool DeclaresVariable
@@ -20,6 +23,17 @@ public abstract class PromptBuildContext
     public SinglePropertyEvaluationContext Context { get; }
 
     public abstract string GenerateOutput(string destination);
+    
+    public string Title { get; }
+    
+    /// <summary>
+    /// Generates a title for the given string with quotes. It will ensure that
+    /// special characters are correctly handled for instance. That "Some \"name\"" will be
+    /// outputted as just that and not "Some "name""
+    /// </summary>
+    /// <param name="title">The string to generate a title for.</param>
+    /// <returns>The generated title.</returns>
+    protected string GenerateTitleString() => SymbolDisplay.FormatLiteral(Title, true);
 
     /// <summary>
     /// The parts that does the prompting. If the prompt result is stored in a variable

--- a/Src/Test/Program.cs
+++ b/Src/Test/Program.cs
@@ -19,7 +19,9 @@ namespace Test
     [AutoSpectreForm(DisableDump = false)]
     public class SClass
     {
-        [TextPrompt(DefaultValueStyle = "yellow", ChoicesStyle = "green on purple")]
+        [TextPrompt(Title = "Add \"item")] public int[] IntItems { get; set; } = Array.Empty<int>();
+        
+        [TextPrompt(DefaultValueStyle = "\"yellow", ChoicesStyle = "green on purple")]
         public bool Yay { get; set; }
 
         [TextPrompt(DefaultValueSource = nameof(FirstNameDefault))] public string FirstName { get; set; } = null!;

--- a/Src/Test/Program.cs
+++ b/Src/Test/Program.cs
@@ -19,10 +19,13 @@ namespace Test
     [AutoSpectreForm(DisableDump = false)]
     public class SClass
     {
-        [TextPrompt(Title = "Add \"item")] public int[] IntItems { get; set; } = Array.Empty<int>();
+        [SelectPrompt(Title = "Select \"name\"")]
+        public string Name { get; set; } = string.Empty;
         
-        [TextPrompt(DefaultValueStyle = "\"yellow", ChoicesStyle = "green on purple")]
-        public bool Yay { get; set; }
+        public IEnumerable<string> NameSource()  {
+            yield return "First";
+            yield return "Second";
+        }
 
         [TextPrompt(DefaultValueSource = nameof(FirstNameDefault))] public string FirstName { get; set; } = null!;
         public const string FirstNameDefault = "Jeppe";


### PR DESCRIPTION
Fixes an issue where Title defined with special characters like for instance "Some \"name\" " would not be rendered correctly when generating source generator code